### PR TITLE
TODOりすとのUIUX改善

### DIFF
--- a/src/main/java/com/example/demo/controller/TodoController.java
+++ b/src/main/java/com/example/demo/controller/TodoController.java
@@ -1,17 +1,21 @@
 package com.example.demo.controller;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.example.demo.model.Todo;
 import com.example.demo.model.User;
@@ -72,6 +76,16 @@ public class TodoController {
         model.addAttribute("count", count);
 
         return "todo-list";
+    }
+
+    @GetMapping("/api/{id}")
+    @ResponseBody
+    public TodoDto getTodoDetail(@PathVariable Long id) {
+        Todo todo = todoService.findById(id);
+        if (todo == null)
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+
+        return new TodoDto(todo); // DTOで返却
     }
 
     @PatchMapping("/{id}/toggle")
@@ -140,6 +154,58 @@ public class TodoController {
         return ResponseEntity.ok(response);
     }
 
+    @PutMapping("/update-ajax/{id}")
+    @ResponseBody
+    public ResponseEntity<?> updateTodoAjax(@PathVariable Long id, @Valid @RequestBody TodoForm form,
+            BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            Map<String, String> errors = new HashMap<>();
+            bindingResult.getFieldErrors().forEach(error -> {
+                errors.put(error.getField(), error.getDefaultMessage());
+            });
+            return ResponseEntity.badRequest().body(errors);
+        }
+
+        LocalDate dueDate = form.getDueDate();
+
+        Todo todo = todoService.findById(id);
+        if (todo == null)
+            return ResponseEntity.notFound().build();
+
+        todo.setTask(form.getTask());
+        todo.setUpdatedAt(LocalDateTime.now(ZoneId.of("Asia/Tokyo")));
+
+        if (dueDate != null) {
+            todo.setDueDate(dueDate);
+        } else {
+            todo.setDueDate(null);
+        }
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません: " + username));
+
+        // グループの処理
+        if (form.getNewGroupName() != null && !form.getNewGroupName().isBlank()) {
+            TaskGroup newGroup = new TaskGroup();
+            newGroup.setName(form.getNewGroupName());
+            newGroup.setUser(user);
+            taskGroupRepository.save(newGroup);
+            todo.setTaskGroup(newGroup);
+        } else if (form.getGroupId() != null) {
+            TaskGroup group = taskGroupRepository.findById(form.getGroupId())
+                    .orElseThrow(() -> new RuntimeException("グループが見つかりません: " + form.getGroupId()));
+            todo.setTaskGroup(group);
+        }
+        todoService.saveTodo(todo);
+
+        // debug
+        System.out.println("form：　　　" + form);
+        System.out.println("デバッグ：　　　" + todo);
+
+        return ResponseEntity.ok(todo);
+    }
+
     @DeleteMapping("/delete/{id}")
     @ResponseBody
     public ResponseEntity<?> deleteTodoAjax(@PathVariable Long id) {
@@ -192,6 +258,39 @@ public class TodoController {
         }
 
         return todos.stream().map(TodoDto::new).toList();
+    }
+
+    @GetMapping("/tab")
+    @ResponseBody
+    public Map<String, List<TodoDto>> getTodosByTab(
+            @RequestParam(required = false) Boolean completed,
+            @RequestParam(defaultValue = "all") String tab,
+            @RequestParam(required = false) Long groupId) {
+
+        String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("ユーザーが見つかりません"));
+
+        List<Todo> todos = todoRepository.findByUserAndCompleted(user, completed);
+        LocalDate today = LocalDate.now();
+
+        List<TodoDto> filtered = todos.stream()
+                .filter(todo -> {
+                    if ("today".equals(tab)) {
+                        return !todo.isCompleted() && todo.getDueDate() != null && !todo.getDueDate().isAfter(today);
+                    } else if ("other".equals(tab)) {
+                        return !todo.isCompleted() && (todo.getDueDate() == null || todo.getDueDate().isAfter(today));
+                    } else if ("completed".equals(tab)) {
+                        return todo.isCompleted();
+                    }
+                    return true;
+                })
+                .filter(todo -> groupId == null
+                        || (todo.getTaskGroup() != null && groupId.equals(todo.getTaskGroup().getId())))
+                .map(TodoDto::new)
+                .toList();
+
+        return Map.of("todos", filtered);
     }
 
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -1,13 +1,18 @@
 /* === カラーパレット（#AA5500ベース） === */
 :root {
-  --primary-color: #AA5500;
+  --primary-color: #d16f24;
   --primary-hover: #8F4400;
   --primary-light: #FFDDB3;
   --secondary-color: #6c757d;
-  --success-color: #28a745;
+  --success-color: #0e925fdb;
   --danger-color: #dc3545;
   --background-color: #fffaf5;
   --text-color: #333;
+  --tab-link-color: #47ae98db;
+  --white-color: #ffffff;
+  --navbar-color: #998c67;
+  --navbar-hover-color: #ffe0b2;
+  --checkbox-border-color: #aa5500;
 }
 
 body {
@@ -20,7 +25,7 @@ body {
 .btn-primary {
   background-color: var(--primary-color);
   border-color: var(--primary-color);
-  color: #fff;
+  color: var(--white-color);
 }
 
 .btn-primary:hover {
@@ -36,22 +41,16 @@ body {
 .btn-outline-primary:hover {
   background-color: var(--primary-light);
   color: var(--primary-hover);
+  border-color: var(--primary-hover);
 }
 
 .btn.btn-primary:active,
-.btn.btn-primary:focus {
-  background-color: var(--primary-light) !important;
-  border-color: var(--primary-light) !important;
-  color: var(--primary-hover) !important;
-  box-shadow: none !important;
-  /* Bootstrapの影も消す */
-}
-
+.btn.btn-primary:focus,
 .btn.btn-outline-primary:active,
 .btn.btn-outline-primary:focus {
   background-color: var(--primary-light) !important;
-  color: var(--primary-hover) !important;
   border-color: var(--primary-light) !important;
+  color: var(--primary-hover) !important;
   box-shadow: none !important;
 }
 
@@ -64,98 +63,12 @@ body {
   height: 20px;
 }
 
-.real-checkbox {
-  opacity: 0;
-  width: 0;
-  height: 0;
-  position: absolute;
-}
-
-.checkmark {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 20px;
-  width: 20px;
-  background-color: #fff;
-  border: 2px solid var(--primary-color);
-  border-radius: 4px;
-  transition: all 0.2s ease;
-}
-
-.real-checkbox:checked+.checkmark {
-  background-color: var(--primary-color);
-}
-
-.checkmark::after {
-  content: "";
-  position: absolute;
-  display: none;
-  left: 6px;
-  top: 2px;
-  width: 5px;
-  height: 10px;
-  border: solid white;
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-}
-
-.real-checkbox:checked+.checkmark::after {
-  display: block;
-}
-
-/* === カードなど === */
-.card {
-  border: 1px solid var(--primary-light);
-  background-color: #fff;
-}
-
-/* === フォームコントロール === */
-.form-control:focus {
-  border-color: var(--primary-color);
-  box-shadow: 0 0 0 0.2rem rgba(170, 85, 0, 0.25);
-}
-
-/* === 見出し === */
-h1,
-h2,
-h3,
-h4,
-h5 {
-  color: var(--primary-color);
-}
-
-/* === navigation === */
-.custom-navbar {
-  background-color: #aa5500;
-}
-
-.custom-navbar .navbar-brand,
-.custom-navbar .nav-link,
-.custom-navbar .navbar-text {
-  color: white;
-}
-
-.custom-navbar .nav-link:hover {
-  color: #ffe0b2;
-  /* 明るめオレンジ */
-}
-
-
-.custom-checkbox {
-  display: inline-block;
-  position: relative;
-  cursor: pointer;
-  width: 20px;
-  height: 20px;
-}
-
 .custom-checkbox input[type="checkbox"] {
   opacity: 0;
-  /* これで元のチェックを非表示 */
   width: 0;
   height: 0;
   position: absolute;
+  margin-right: 6px;
 }
 
 .custom-checkbox .checkmark {
@@ -164,14 +77,14 @@ h5 {
   left: 0;
   height: 20px;
   width: 20px;
-  background-color: #fff;
-  border: 2px solid #AA5500;
+  background-color: var(--white-color);
+  border: 2px solid var(--checkbox-border-color);
   border-radius: 4px;
   transition: all 0.2s ease;
 }
 
-.custom-checkbox input[type="checkbox"]:checked+.checkmark {
-  background-color: #AA5500;
+.custom-checkbox input[type="checkbox"]:checked + .checkmark {
+  background-color: var(--checkbox-border-color);
 }
 
 .custom-checkbox .checkmark::after {
@@ -182,15 +95,86 @@ h5 {
   top: 2px;
   width: 5px;
   height: 10px;
-  border: solid white;
+  border: solid var(--white-color);
   border-width: 0 2px 2px 0;
   transform: rotate(45deg);
 }
 
-.custom-checkbox input[type="checkbox"]:checked+.checkmark::after {
+.custom-checkbox input[type="checkbox"]:checked + .checkmark::after {
   display: block;
 }
 
+/* === カードなど === */
+.card {
+  border: 1px solid var(--primary-light);
+  background-color: var(--white-color);
+}
+
+/* === フォーム === */
+.form-control:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 0.2rem rgba(170, 85, 0, 0.25);
+}
+
+/* === 見出し === */
+h1, h2, h3, h4, h5 {
+  color: var(--primary-color);
+}
+
+/* === ナビゲーションバー === */
+.custom-navbar {
+  background-color: var(--navbar-color);
+}
+
+.custom-navbar .navbar-brand,
+.custom-navbar .nav-link,
+.custom-navbar .navbar-text {
+  color: var(--white-color);
+}
+
+.custom-navbar .nav-link:hover {
+  color: var(--navbar-hover-color);
+}
+
+/* === タブ & タスク追加ボタン === */
+.nav-tabs {
+  border-bottom: 2px solid var(--primary-color);
+}
+
+.nav-tabs .nav-link {
+  color: var(--success-color);
+  font-weight: 600;
+  font-size: 1rem;
+  border: none;
+  border-radius: 0.5rem 0.5rem 0 0;
+}
+
+.nav-tabs .nav-link.active {
+  color: var(--danger-color);
+  border-bottom: 3px solid var(--primary-color);
+  background-color: transparent;
+}
+
+.tab-content {
+  background-color: transparent;
+  padding: 1.5rem;
+}
+
+.add-task-btn {
+  background-color: var(--success-color);
+  font-weight: 300;
+  border: none;
+  border-radius: 8px;
+  font-size: 15px;
+  cursor: pointer;
+  transition: background-color 0.2s ease-in-out;
+}
+
+.add-task-btn:hover {
+  background-color: var(--tab-link-color);
+}
+
+/* === タイトル・補助UI === */
 .top-title {
   position: relative;
   display: inline-block;
@@ -207,14 +191,37 @@ h5 {
   word-break: break-word;
 }
 
-.custom-checkbox input[type="checkbox"] {
-  margin-right: 6px;
-}
-
 #newGroupInputContainer {
   transition: all 0.3s ease;
 }
 
-.custom-navbar {
-  background-color: #a35b00;
+/* タスクリストのアイテム */
+.list-group-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.btn-link.dropdown-toggle::after {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .tab-content {
+    background-color: transparent;
+    padding: 0.5rem 0
+  }
+
+  .list-group-item .d-flex.align-items-center {
+    flex-direction: row
+  }
+
+  .list-group-item .task-due {
+    margin-top: 5px;
+  }
+
+  .list-group-item .task-span {
+    margin-bottom: 5px;
+  }
 }

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -18,6 +18,13 @@
 
     <!-- CSS -->
     <link rel="stylesheet" th:href="@{/css/style.css}">
+
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP&display=swap" rel="stylesheet">
+    <style>
+      body {
+        font-family: 'Noto Sans JP', sans-serif;
+      }
+    </style>
 </head>
 
 <body>

--- a/src/main/resources/templates/todo-list.html
+++ b/src/main/resources/templates/todo-list.html
@@ -4,13 +4,154 @@
 <body>
   <div th:fragment="content" class="container my-4">
     <div th:replace="fragments/group-modals :: groupModals"></div>
-    <h1 class="text-center mb-4">TODOリスト</h1>
+    <div class="row my-3">
+      <!-- タスク追加ボタン -->
+      <div class="col-5 col-md-6">
+        <button class="btn btn-success add-task-btn" data-bs-toggle="modal" data-bs-target="#addTaskModal">
+          ＋ タスク追加
+        </button>
+      </div>
+      <div class="col-7 col-md-6 text-center text-md-end">
+        <div class="dropdown">
+          <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="groupSortDropdown"
+            data-bs-toggle="dropdown" aria-expanded="false">
+            グループで絞り込む
+          </button>
+          <ul id="groupSortList" class="dropdown-menu dropdown-menu-end" aria-labelledby="groupSortDropdown">
+            <li><a class="dropdown-item" href="#" onclick="sortByGroup('')">全て</a></li>
+            <li th:each="group : ${groups}" class="d-flex justify-content-between align-items-center px-2">
+              <a class="dropdown-item flex-grow-1" href="#" th:attr="onclick='sortByGroup(' + ${group.id} + ')'"
+                th:text="${group.name}"></a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
 
-    <!-- タスク追加ボタン -->
-    <div class="text-end mb-4">
-      <button class="btn btn-success" data-bs-toggle="modal" data-bs-target="#addTaskModal">
-        ＋ タスクを追加
-      </button>
+    <!-- 見出しとソート -->
+    <div class="row align-items-center">
+      <div class="d-flex flex-wrap align-items-center gap-2">
+        <!-- タブメニュー -->
+        <ul class="nav nav-tabs" id="taskTabs" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="today-tab" data-bs-toggle="tab" data-bs-target="#today-tab-pane"
+              th:attr="data-tab=today" type="button">
+              今日まで
+            </button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="other-tab" data-bs-toggle="tab" data-bs-target="#other-tab-pane"
+              th:attr="data-tab=other" type="button">
+              その他
+            </button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="completed-tab" data-bs-toggle="tab" data-bs-target="#completed-tab-pane"
+              th:attr="data-tab=completed" type="button">
+              完了済み
+            </button>
+          </li>
+        </ul>
+      </div>
+      <div id="task-counter">
+        <p>残りのタスク数: {{ remainingTasks }}</p>
+      </div>
+    </div>
+
+    <div class="tab-content mb-5" id="taskTabContent">
+      <!-- 今日まで -->
+      <div class="tab-pane show active" id="today-tab-pane" role="tabpanel" aria-labelledby="today-tab">
+        <ul class="list-group" id="todayTasksList">
+          <li th:each="todo : ${dueFutureOrNoDate}" th:id="'todo-' + ${todo.id}" th:data-groupid="${todo.taskGroup?.id}"
+            class="list-group-item d-flex justify-content-between align-items-center">
+            <div class="d-flex align-items-center gap-3">
+              <label class="custom-checkbox m-0">
+                <input type="checkbox" class="real-checkbox" th:attr="data-id=${todo.id}" name="checkbox-today"
+                  onchange="toggleCompleted(this)" />
+                <span class="checkmark"></span>
+              </label>
+              <span th:text="${todo.task}" class="fs-5 task-span"></span>
+              <small class="task-due text-muted" th:if="${todo.dueDate}"
+                th:text="'期限: ' + ${#temporals.format(todo.dueDate, 'yyyy/MM/dd')}"></small>
+              <small class="task-due text-muted" th:if="!${todo.dueDate}"></small>
+            </div>
+            <div class="d-flex gap-2">
+              <button type="button" class="btn btn-outline-primary btn-sm"
+                th:attr="data-id=${todo.id}, data-task=${todo.task}, data-due=${todo.dueDate}"
+                onclick="openEditModalFromButton(this)">
+                編集
+              </button>
+              <button type="button" class="btn btn-outline-danger btn-sm" th:attr="data-id=${todo.id}"
+                onclick="showDeleteConfirmModal(this)">
+                削除
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <!-- その他 -->
+      <div class="tab-pane" id="other-tab-pane" role="tabpanel" aria-labelledby="other-tab">
+        <ul class="list-group" id="otherTasksList">
+          <li th:each="todo : ${dueFutureOrNoDate}" th:id="'todo-' + ${todo.id}" th:data-groupid="${todo.taskGroup?.id}"
+            class="list-group-item d-flex justify-content-between align-items-center">
+            <div class="d-flex align-items-center gap-3">
+              <label class="custom-checkbox m-0">
+                <input type="checkbox" class="real-checkbox" th:attr="data-id=${todo.id}" name="checkbox-other"
+                  onchange="toggleCompleted(this)" />
+                <span class="checkmark"></span>
+              </label>
+              <span th:text="${todo.task}" class="fs-5 task-span"></span>
+              <small class="task-due text-muted" th:if="${todo.dueDate}"
+                th:text="'期限: ' + ${#temporals.format(todo.dueDate, 'yyyy/MM/dd')}"></small>
+              <small class="task-due text-muted" th:if="!${todo.dueDate}"></small>
+            </div>
+            <div class="d-flex gap-2">
+              <button type="button" class="btn btn-outline-primary btn-sm"
+                th:attr="data-id=${todo.id}, data-task=${todo.task}, data-due=${todo.dueDate}"
+                onclick="openEditModalFromButton(this)">
+                編集
+              </button>
+              <button type="button" class="btn btn-outline-danger btn-sm" th:attr="data-id=${todo.id}"
+                onclick="showDeleteConfirmModal(this)">
+                削除
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <!-- 完了済み -->
+      <div class="tab-pane" id="completed-tab-pane" role="tabpanel" aria-labelledby="completed-tab">
+        <ul class="list-group" id="completedTasksList">
+          <li th:each="todo : ${todos}" th:if="${todo.completed}" th:id="'todo-' + ${todo.id}"
+            th:data-groupid="${todo.taskGroup?.id}"
+            class="list-group-item d-flex justify-content-between align-items-center">
+            <div class="d-flex align-items-center gap-3">
+              <label class="custom-checkbox">
+                <input type="checkbox" class="real-checkbox" th:attr="data-id=${todo.id}" name="checkbox-completed"
+                  onchange="toggleCompleted(this)" checked />
+                <span class="checkmark"></span>
+              </label>
+              <span th:text="${todo.task}" class="fs-5 task-span text-start"></span>
+              <small class="task-due text-muted" th:if="${todo.dueDate}"
+                th:text="'期限: ' + ${#temporals.format(todo.dueDate, 'yyyy/MM/dd')}"></small>
+              <small class="task-due text-muted" th:if="!${todo.dueDate}"></small>
+            </div>
+            <div class="d-flex gap-2">
+              <button type="button" class="btn btn-outline-primary btn-sm"
+                th:attr="data-id=${todo.id}, data-task=${todo.task}, data-due=${todo.dueDate}"
+                onclick="openEditModalFromButton(this)">
+                編集
+              </button>
+              <button type="button" class="btn btn-outline-danger btn-sm" th:attr="data-id=${todo.id}"
+                onclick="showDeleteConfirmModal(this)">
+                削除
+              </button>
+            </div>
+          </li>
+        </ul>
+      </div>
     </div>
 
     <!-- タスク追加モーダル -->
@@ -46,88 +187,6 @@
       </div>
     </div>
 
-    <!-- 未完了のタスク -->
-    <div class="row align-items-center mb-3">
-      <div class="col-6 col-md-6 d-flex flex-wrap align-items-center gap-2 mb-2 mb-md-0">
-        <h3 class="mb-0 text-nowrap">未完了のタスク</h3>
-        <span class="badge bg-secondary">
-          <span id="incompleteCountNumber" th:text="${count}">0</span> 件表示中
-        </span>
-      </div>
-      <div class="col-6 col-md-6 text-center text-md-end">
-        <div class="dropdown">
-          <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="groupSortDropdown"
-            data-bs-toggle="dropdown" aria-expanded="false">
-            グループでソート
-          </button>
-          <ul id="groupSortList" class="dropdown-menu dropdown-menu-end" aria-labelledby="groupSortDropdown">
-            <li><a class="dropdown-item" href="#" onclick="sortByGroup('')">全て</a></li>
-            <li th:each="group : ${groups}" class="d-flex justify-content-between align-items-center px-2">
-              <a class="dropdown-item flex-grow-1" href="#" th:attr="onclick='sortByGroup(' + ${group.id} + ')'"
-                th:text="${group.name}"></a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </div>
-
-    <ul class="list-group mb-4" id="incompleteTasksList">
-      <li th:each="todo : ${todos}" th:if="${!todo.completed}" th:id="'todo-' + ${todo.id}"
-        class="list-group-item d-flex justify-content-between align-items-center">
-        <div class="d-flex align-items-center gap-3">
-          <label class="custom-checkbox m-0">
-            <input type="checkbox" class="real-checkbox" th:attr="data-id=${todo.id}"
-              onchange="toggleCompleted(this)" />
-            <span class="checkmark"></span>
-          </label>
-          <span th:text="${todo.task}" class="fs-5 task-span"></span>
-        </div>
-        <div class="d-flex gap-2">
-          <button type="button" class="btn btn-outline-primary btn-sm"
-            th:attr="data-id=${todo.id}, data-task=${todo.task}" onclick="openEditModalFromButton(this)">
-            編集
-          </button>
-          <button type="button" class="btn btn-outline-danger btn-sm" th:attr="data-id=${todo.id}"
-            onclick="showDeleteConfirmModal(this)">
-            削除
-          </button>
-        </div>
-      </li>
-    </ul>
-
-    <!-- 完了済みのタスク -->
-    <button id="toggleCompletedTasksBtn" class="btn btn-secondary mb-3" type="button" data-bs-toggle="collapse"
-      data-bs-target="#completedTasks" aria-expanded="false" aria-controls="completedTasks">
-      完了済みのタスクを表示
-    </button>
-
-    <div class="collapse" id="completedTasks">
-      <h3 class="mb-3">完了済みのタスク</h3>
-      <ul class="list-group" id="completedTasksList">
-        <li th:each="todo : ${todos}" th:if="${todo.completed}"
-          class="list-group-item d-flex justify-content-between align-items-center">
-          <div class="d-flex align-items-center gap-3">
-            <label class="custom-checkbox">
-              <input type="checkbox" class="real-checkbox" th:attr="data-id=${todo.id}" onchange="toggleCompleted(this)"
-                checked />
-              <span class="checkmark"></span>
-            </label>
-            <span th:text="${todo.task}" class="fs-5 task-span text-start"></span>
-          </div>
-          <div class="d-flex gap-2">
-            <button type="button" class="btn btn-outline-primary btn-sm"
-              th:attr="data-id=${todo.id}, data-task=${todo.task}" onclick="openEditModalFromButton(this)">
-              編集
-            </button>
-            <button type="button" class="btn btn-outline-danger btn-sm" th:attr="data-id=${todo.id}"
-              onclick="showDeleteConfirmModal(this)">
-              削除
-            </button>
-          </div>
-        </li>
-      </ul>
-    </div>
-
     <!-- 編集モーダル -->
     <div class="modal fade" id="editModal" tabindex="-1">
       <div class="modal-dialog">
@@ -137,7 +196,26 @@
             <button class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
-            <input type="text" class="form-control" id="editTaskInput" />
+            <div class="my-1">
+              <label class="mb-1">タスク名</label>
+              <input type="text" class="form-control" id="editTaskInput" name="editTaskInput" />
+            </div>
+            <div class="my-1">
+              <label class="mb-1">期日</label>
+              <input type="date" class="form-control" id="editDueInput" name="editDueInput" />
+            </div>
+            <div class="mb-3 my-1">
+              <label for="taskGroupSelect" class="form-label">タスクグループ</label>
+              <select id="taskGroupSelectForEdit" class="form-select">
+                <option value="">-- グループを選択 --</option>
+                <option value="__new__">新しいグループを作成</option>
+                <option th:each="group : ${groups}" th:value="${group.id}" th:text="${group.name}"></option>
+              </select>
+            </div>
+            <div id="newGroupInputContainerForEdit" class="mb-3 my-1" style="display: none;">
+              <label for="newGroupName" class="form-label">新しいグループ名</label>
+              <input type="text" id="newGroupNameForEdit" class="form-control" name="newGroupNameForEdit">
+            </div>
           </div>
           <div class="modal-footer">
             <button class="btn btn-secondary" data-bs-dismiss="modal">キャンセル</button>


### PR DESCRIPTION
タスクの状態のタブ選択に変更
　→それに伴い、todolistの初期表示をapiで対応
　
SP表示の調整
　→デザインの崩れの修正と編集削除ボタンの3点リーダー対応
　→その他微調整の実施